### PR TITLE
Fix sent status

### DIFF
--- a/scheduled_sending.php
+++ b/scheduled_sending.php
@@ -1033,6 +1033,8 @@ $rc = $this->rc;
                             }
                         }
                     }
+                    $db->query("UPDATE $table SET status = 'sent', updated_at = NOW() WHERE id = ?", $id);
+                    $sent_ok++;
                 } catch (\Exception $e) {
                     $this->ss_debug(array('msg'=>'worker imap err','err'=>$e->getMessage()));
                 }


### PR DESCRIPTION
Updated status in mysql to prevent resending the same scheduled message multiple times. Updated the sent counter so the log message is correct.