### PR TITLE
Fix scheduled messages timezone config loading

### DIFF
--- a/scheduled_sending.php
+++ b/scheduled_sending.php
@@ -1000,6 +1000,10 @@ class scheduled_sending extends rcube_plugin
     {
         $this->rc = rcmail::get_instance();
 
+		// Load plugin config for all tasks/actions so scheduled_timezone is available
+		// also in Settings > Scheduled messages, not only in worker/send_due actions.		
+		$this->load_config();
+
         // Load plugin localization for all tasks/actions
         $this->add_texts('localization', true);
 


### PR DESCRIPTION
Bevor the fix
<img width="990" height="165" alt="image" src="https://github.com/user-attachments/assets/0adb6c55-dd0f-4d46-bcce-ba7d78007d36" />

<br>
After the fix
<img width="991" height="170" alt="image" src="https://github.com/user-attachments/assets/dbe6f3ae-1af9-4263-87b0-95bedf39f5b6" />
<br><br>

This pull request fixes a timezone display issue in the scheduled messages overview.

The plugin already supports the scheduled_timezone configuration option, for example:

$config['scheduled_timezone'] = 'Europe/Berlin';

However, the plugin configuration was not loaded early enough for all actions/tasks. As a result, the scheduled messages list in the settings page could fall back to the default timezone value UTC, even though scheduled_timezone was correctly set in the plugin config.

This caused scheduled messages to be displayed with the raw UTC time in the settings overview. For example, a message scheduled for 10:39 in Europe/Berlin was stored correctly as 08:39 UTC in the database, but the settings page also displayed 08:39, making it look like the scheduled time was two hours in the past.

The database value itself is correct because scheduled_at is stored in UTC. The issue is only the display conversion in the settings page.

By loading the plugin configuration during init(), scheduled_timezone is available not only for the worker/send_due actions, but also for the settings page. This allows the scheduled messages overview to correctly convert the stored UTC value back to the configured local timezone before displaying it.

Tested with:

Roundcube 1.6.x
PHP 8.4
scheduled_timezone = Europe/Berlin
Scheduled message stored as UTC in scheduled_queue.scheduled_at Settings overview now correctly displays the local scheduled time